### PR TITLE
Replace the `request` property with `resourcePath`

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,5 +12,5 @@ module.exports = function(source) {
         this.cacheable();
     }
 
-    return instrumenter.instrumentSync(source, this.request);
+    return instrumenter.instrumentSync(source, this.resourcePath);
 };


### PR DESCRIPTION
Since this should be the last step in our `postLoaders` we should provide `resourcePath` instead to let `coverage` and other karma reporters get access to the proper path, so we can e.g. generate proper lcov data, and not data containing incorrect path data. 

For example, using `request` we receive `lcov` data like this:
https://gist.github.com/srn/3c23d0fbb508f478a7b2

Using `resourcePath` we get the real deal instead:
https://gist.github.com/srn/03f440987394f2b4486a
