### PR TITLE
fix: throws when pitching loader is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var istanbul = require('istanbul');
+var cache = {};
 
 module.exports = function(source) {
     var instrumenter = new istanbul.Instrumenter({
@@ -12,5 +13,9 @@ module.exports = function(source) {
         this.cacheable();
     }
 
-    return instrumenter.instrumentSync(source, this.resourcePath);
+    if (!cache[this.resourcePath]) {
+        cache[this.resourcePath] = instrumenter.instrumentSync(source, this.resourcePath);
+    }
+
+    return cache[this.resourcePath];
 };


### PR DESCRIPTION
Oh, this issue is still here...

I'm sorry not to respond in time, but @sokra - you were completely right. The only issue, that your solution does not work very well for instrumenter. It generates crazy filenames and file tree structure becomes totally broken.

Our solution was to always require files in the same manner and do not use different transformations on the same file in the project (including tests). Which worked quite well until I hit the issue again today.

My particular problem now was that in one case module is required as is (in one legacy test) and in the other case - with `inject-loader`. I debugged this loader and found that the same file is included twice, but the code is different (`this.request` is obviously different for them either: one has `inject-loader` and the other one does not). The difference in code is minimal, but enough to give bunch of errors with istanbul report.

![20150528-140631](https://cloud.githubusercontent.com/assets/175264/7852557/c8d158ac-0542-11e5-898d-e90080ce2091.png)

I came up with two solutions at the moment:
1. Update legacy testcase with proper dependency (with `inject-loader`). Completely legit and working solution with minimal effort
2. Update `istanbul-instrumenter-loader` itself to handle this issue.

Here is a PR which fixes the issue.

It is up to discussion if this solution is completely correct, but it solves the problem and works for us. I'd love to hear some comments on this and how this solution can potentially distort coverage report in case of some funky loaders being used.

The other thing that I am not sure if the solution is completely correct - coverage report generations in file watching mode. It seems like an edge case.
