### PR TITLE
Fix loader-utils warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(source, sourceMap) {
         sourceMap = inlineSourceMap.sourcemap;
     }
 
-    var userOptions = loaderUtils.parseQuery(this.query);
+    var userOptions = loaderUtils.getOptions(this) || {};
     var instrumenter = istanbulLibInstrument.createInstrumenter(
         assign({ produceSourceMap: this.sourceMap }, userOptions)
     );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "convert-source-map": "^1.3.0",
     "istanbul-lib-instrument": "^1.1.3",
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.0.2",
     "object-assign": "^4.1.0"
   },
   "engines": {


### PR DESCRIPTION
Update to loader-utils v1.0 and change the call from `parseQuery` to `getOptions`

Context here: https://github.com/webpack/loader-utils/issues/56