### PR TITLE
feat(optionsLoader): Remove deprecated parseQuery form codebase

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(source, sourceMap) {
         sourceMap = inlineSourceMap.sourcemap;
     }
 
-    var userOptions = loaderUtils.parseQuery(this.query);
+    var userOptions = loaderUtils.getOptions(this);
     var instrumenter = istanbulLibInstrument.createInstrumenter(
         assign({ produceSourceMap: this.sourceMap }, userOptions)
     );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "convert-source-map": "^1.3.0",
     "istanbul-lib-instrument": "^1.1.3",
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.1.0",
     "object-assign": "^4.1.0"
   },
   "engines": {


### PR DESCRIPTION
Due to webpack/loader-utils#56 the parseQuery is
now deprecated, and we should instead use
getOptions.