### PR TITLE
Fix anchor links on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Instrument JS files with [istanbul-lib-instrument](https://github.com/istanbuljs
 npm i -D istanbul-instrumenter-loader
 ```
 
-<h2 align="center"><a href="https://webpack.js.org/concepts/loaders">Usage</a></h2>
+<h2 align="center">Usage</h2>
 
 ### `References`
 
@@ -111,7 +111,7 @@ You must run the instrumentation as a post step
 }
 ```
 
-<h2 align="center"><a href="https://github.com/istanbuljs/istanbuljs/blob/master/packages/istanbul-lib-instrument/api.md#instrumenter">Options</a></h2>
+<h2 align="center">Options</h2>
 
 The loader supports all options supported by `istanbul-lib-instrument`
 


### PR DESCRIPTION
It seems anchor links are generated automatically (looking at other contrib files) - so a tags just break the template.

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
