### PR TITLE
Change the Babel integration recommendation to `enforce: 'pre'`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ config.set({
 
 ### with `Babel`
 
-You must run the instrumentation as a post step
+You must run the instrumentation as a pre step
 
 **webpack.config.js**
 ```js
@@ -106,7 +106,7 @@ You must run the instrumentation as a post step
     loader: 'istanbul-instrumenter-loader',
     options: { esModules: true }
   },
-  enforce: 'post',
+  enforce: 'pre',
   exclude: /node_modules|\.spec\.js$/,
 }
 ```


### PR DESCRIPTION
See https://github.com/webpack-contrib/istanbul-instrumenter-loader/issues/86#issuecomment-468795404

<!--
1. [Read and sign the CLA](https://cla.js.foundation/webpack/webpack.js.org). This needs to be done only once. PRs that haven't signed it won't be accepted.
2. Check out the [development guide](https://webpack.js.org/development/) for the API and development guidelines.
3. Read through the PR diff carefully as sometimes this can reveal issues. The work will be reviewed, but this can save some effort.
-->
